### PR TITLE
taking care of the last moves in initial sequence

### DIFF
--- a/src/bayesian.py
+++ b/src/bayesian.py
@@ -12,10 +12,6 @@ def init_prior_uniform(n):
     return 1 / n
 
 
-def normalising_constant(priors, likelihoods):
-    return sum([p * l for p, l in zip(priors, likelihoods)])
-
-
 def posterior(priors, likelihoods):
     a = np.array([x * y for x, y in zip(priors, likelihoods)])
     a /= sum(a)

--- a/src/mockup.py
+++ b/src/mockup.py
@@ -44,10 +44,21 @@ def calculate_payoff_matrix(benefit, cost, delta, epsilon):
     for i, player in enumerate(pure_memory_one_strategies):
         for j, co_player in enumerate(pure_memory_one_strategies):
             ss = stationary.stationary(player, co_player, epsilon=epsilon, delta=delta)
-            payoff_matrix[i, j] = sum(ss @ np.array([benefit - cost, -cost, benefit, 0]))
+            payoff_matrix[i, j] = ss @ np.array([benefit - cost, -cost, benefit, 0])
 
     return payoff_matrix
 
+mat = calculate_payoff_matrix(benefit, cost, delta, epsilon)
+print(mat)
+print(mat.shape)  # => (32,32)
+mat[0][0]    # => 0.0 (AllD vs AllD)
+mat[31][31]  # => benefit-cost (AllC vs AllC)
+mat[0][31]   # => benefit (AllD vs AllC)
+mat[31][0]   # => -cost (AllC vs AllD)
+mat[25][25]  # benefit-cost (WSLS-c vs WSLS-c)
+mat[8] == mat[0] # GT-d behaves like AllD
+
+# %%
 def infer_best_response_and_expected_payoffs(history, payoff_matrix):
     """Based on a given initial sequences (history) we try to infer the strategy
     of the co-player.
@@ -91,6 +102,8 @@ def infer_best_response_and_expected_payoffs(history, payoff_matrix):
 
     return bs, exp_p
 
+
+# %%
 def long_term_payoffs(
     opening_payoffs, exp_p, delta
 ):

--- a/src/mockup.py
+++ b/src/mockup.py
@@ -26,7 +26,7 @@ cost = PARAMETERS["cost"]
 action_map = {1: C, 0: D}
 
 # %%
-def print_strategy(idx):
+def idx_to_strategy(idx, print = False):
     if idx < 0 or idx > 31:
         raise ValueError("idx must be between 0 and 31")
     init = C if idx & 0b10000 > 0 else D
@@ -34,12 +34,9 @@ def print_strategy(idx):
     pcd =  C if idx & 0b00100 > 0 else D
     pdc =  C if idx & 0b00010 > 0 else D
     pdd =  C if idx & 0b00001 > 0 else D
-    print(f"init: {init}, pcc: {pcc}, pcd: {pcd}, pdc: {pdc}, pdd: {pdd}")
+    if print:
+        print(f"init: {init}, pcc: {pcc}, pcd: {pcd}, pdc: {pdc}, pdd: {pdd}")
     return (init, pcc, pcd, pdc, pdd)
-
-print_strategy(0b00000)  # ALLD-d
-print_strategy(25)  # WSLS-c
-print_strategy(10)  # TFT-d
 
 # %%
 
@@ -64,15 +61,6 @@ def calculate_payoff_matrix(benefit, cost, delta, epsilon):
 
     return payoff_matrix
 
-mat = calculate_payoff_matrix(benefit, cost, delta, epsilon)
-print(mat)
-print(mat.shape)  # => (32,32)
-mat[0][0]    # => 0.0 (AllD vs AllD)
-mat[31][31]  # => benefit-cost (AllC vs AllC)
-mat[0][31]   # => benefit (AllD vs AllC)
-mat[31][0]   # => -cost (AllC vs AllD)
-mat[25][25]  # benefit-cost (WSLS-c vs WSLS-c)
-mat[8] == mat[0] # GT-d behaves like AllD
 
 # %%
 def posterior_distribution(history):
@@ -135,20 +123,6 @@ def posterior_distribution(history):
     return prior
 
 
-# history = [(C,C)]
-# posterior_distribution(history)  #=> [1/16] * 16
-
-# history = [(C,C),(D,D)]
-# posterior_distribution(history)   #=> [1/8] * 8 + [0] * 8
-
-# history = [(C,C),(D,D),(D,C)]
-# posterior_distribution(history)   # => [0, 0.25] * 4 + [0] * 8
-
-history = [(C,C),(D,D),(D,C),(C,D),(D,C)]
-posterior_distribution(history)   # => [0,0,0,0,0,1,0,0,...0]
-
-# history = [(D,D),(D,D),(D,C)]   # for inconsistent history
-# posterior_distribution(history)   # => raise Exeception
 # %%
 def infer_best_response_and_expected_payoffs(history, payoff_matrix):
     """Based on a given initial sequences (history) we try to infer the strategy

--- a/src/mockup.py
+++ b/src/mockup.py
@@ -90,15 +90,7 @@ def posterior_distribution(history):
                     if i & 0b1000 != 0:
                         prior[i] = 0
         if prev == (C,D):
-            if curr == C:
-                for i in range(16):
-                    if i & 0b0100 == 0:
-                        prior[i] = 0
-            if curr == D:
-                for i in range(16):
-                    if i & 0b0100 != 0:
-                        prior[i] = 0
-        if prev == (D,C):
+            # from co-player's viewpoint, this is (D,C)
             if curr == C:
                 for i in range(16):
                     if i & 0b0010 == 0:
@@ -106,6 +98,16 @@ def posterior_distribution(history):
             if curr == D:
                 for i in range(16):
                     if i & 0b0010 != 0:
+                        prior[i] = 0
+        if prev == (D,C):
+            # from co-player's viewpoint, this is (C,D)
+            if curr == C:
+                for i in range(16):
+                    if i & 0b0100 == 0:
+                        prior[i] = 0
+            if curr == D:
+                for i in range(16):
+                    if i & 0b0100 != 0:
                         prior[i] = 0
         if prev == (D,D):
             if curr == C:

--- a/src/mockup.py
+++ b/src/mockup.py
@@ -6,7 +6,6 @@ import numpy as np
 #%%
 from axelrod.action import Action
 
-import bayesian
 import stationary
 
 C, D = Action.C, Action.D
@@ -55,10 +54,11 @@ def infer_best_response_and_expected_payoffs(history, payoff_matrix):
     
     We calculate the posterior distribution given that co-player's
     strategy is in Delta. Namely, the posterior distribution: $p(i)$, where $i$
-    is the index of the strategy $[1, 32]$.
+    is the index of the strategy $[1, 16]$.
 
     We then calculate the long term payoffs for the player $\pi(i, j)$
-    of strategy $i$ against strategy $j$
+    of strategy $i$ against strategy $j$.
+    Here, the we consider the case where the initial moves are history[-1] because players continue the game after the initial moves.
 
     If the focal player takes strategy $1$, for instance, the expected long-term 
     payoff $P(1) = $\sum_i \pi(1, i) p(i)$.
@@ -68,56 +68,28 @@ def infer_best_response_and_expected_payoffs(history, payoff_matrix):
     """
 
     posterior = posterior_distribution(history)
-    # For testing purpose
-    # print(np.argmax(posterior))
+    initial_coplayer_move = history[-1][1]
+    # we consider a repeated game starting from t=(len(history)-1)
+    if initial_coplayer_move == C:
+        posterior = [0] * 16 + posterior
+    else:
+        posterior = posterior + [0] * 16
+    print(history,posterior)
 
     expected_payoffs = np.sum(payoff_matrix * posterior, axis=1)
+
+    initial_focal_player_move = history[-1][0]
+    if initial_focal_player_move == C:
+        # we have to choose the best response from [16, 31]
+        expected_payoffs = expected_payoffs[:16] + [-np.inf] * 16
+    else:
+        # we have to choose the best response from [0, 15]
+        expected_payoffs = [-np.inf] * 16 + expected_payoffs[16:]
 
     bs = np.argmax(expected_payoffs)
     exp_p = np.max(expected_payoffs)
 
     return bs, exp_p
-
-def posterior_distribution(history):
-    """Compute the posterior distribution of the opponent's strategy."""
-    num_possible_s = 32
-    last_turn_outcomes = ["p0"] + list(itertools.product([C, D], repeat=2))
-    pure_transitions = list(itertools.product([D, C], repeat=5))
-    pure_strategies = {
-        f"M{i}": {k: v for k, v in zip(last_turn_outcomes, transitions)}
-        for i, transitions in enumerate(pure_transitions)
-    }
-    strategies_to_fit = [
-        bayesian.MemoryOne(error=epsilon, states_action_dict=value)
-        for value in pure_strategies.values()
-    ]
-
-    priors = [bayesian.init_prior_uniform(num_possible_s)] * num_possible_s
-
-    coplayers_actions = [h[1] for h in history]
-
-    # Opening Move
-    opening_move = coplayers_actions[0]
-
-    likelihoods = [
-        strategy.likelihood(opening_move, "p0")
-        for strategy in strategies_to_fit
-    ]
-    posteriors = bayesian.posterior(priors, likelihoods)
-    priors = posteriors
-
-    # The rest
-    for turn, turn_action in enumerate(coplayers_actions[1:]):
-        likelihoods = [
-            strategy.likelihood(turn_action, history[turn][::-1])
-            for strategy in strategies_to_fit
-        ]
-
-        posteriors = bayesian.posterior(priors, likelihoods)
-
-        priors = posteriors
-
-    return priors
 
 def long_term_payoffs(
     opening_payoffs, exp_p, delta
@@ -129,6 +101,84 @@ def long_term_payoffs(
     # print(payoffs, exp_p)
     return payoffs + exp_p * delta ** len(opening_payoffs) / (1.0-delta)
 
+# %%
+def posterior_distribution(history):
+    """
+    Infer the co-player's strategy based on the history of the game.
+    history is a list of tuples (focal player, co-player) such as
+        [(C, C), (C, D), (D, C), (D, D)].
+    Returns a list of posterior probabilities of the co-player's strategy.
+        [p_0, p_2, ..., p_15]
+    We assume that the co-player's strategy is pure memory-one and there is no implementation error.
+    If an inconsistent history is given, it raises ValueError.
+    """
+    # strategy is described by (p_cc, p_cd, p_dc, p_dd)
+    # index = 8 * p_cc + 4 * p_cd + 2 * p_dc + p_dd
+    prior = [1.0/16.0] * 16
+    # for two successive turns
+    for turn in range(1, len(history)):
+        prev = history[turn-1]  # previous moves
+        curr = history[turn][1] # co-players' current move
+        print(prev,curr)
+        if prev == (C,C):
+            if curr == C:
+                for i in range(16):
+                    if i & 0b1000 == 0:
+                        prior[i] = 0
+            if curr == D:
+                print("aaa")
+                for i in range(16):
+                    print(i)
+                    if i & 0b1000 != 0:
+                        prior[i] = 0
+        if prev == (C,D):
+            if curr == C:
+                for i in range(16):
+                    if i & 0b0100 == 0:
+                        prior[i] = 0
+            if curr == D:
+                for i in range(16):
+                    if i & 0b0100 != 0:
+                        prior[i] = 0
+        if prev == (D,C):
+            if curr == C:
+                for i in range(16):
+                    if i & 0b0010 == 0:
+                        prior[i] = 0
+            if curr == D:
+                for i in range(16):
+                    if i & 0b0010 != 0:
+                        prior[i] = 0
+        if prev == (D,D):
+            if curr == C:
+                for i in range(16):
+                    if i & 0b0001 == 0:
+                        prior[i] = 0
+            if curr == D:
+                for i in range(16):
+                    if i & 0b0001 != 0:
+                        prior[i] = 0
+    # normalize prior
+    if sum(prior) == 0:
+        raise ValueError("Inconsistent history")
+    prior = [p/sum(prior) for p in prior]
+    return prior
+
+
+# history = [(C,C)]
+# posterior_distribution(history)  #=> [1/16] * 16
+
+# history = [(C,C),(D,D)]
+# posterior_distribution(history)   #=> [1/8] * 8 + [0] * 8
+
+# history = [(C,C),(D,D),(D,C)]
+# posterior_distribution(history)   # => [0, 0.25] * 4 + [0] * 8
+
+history = [(C,C),(D,D),(D,C),(C,D),(D,C)]
+posterior_distribution(history)   # => [0] * 5 + [1] + [0] * 10
+
+# history = [(D,D),(D,D),(D,C)]   # for inconsistent history
+# posterior_distribution(history)   # => raise Exeception
 # %%
 
 if __name__ == "__main__":

--- a/src/mockup.py
+++ b/src/mockup.py
@@ -39,7 +39,6 @@ def idx_to_strategy(idx, print = False):
     return (init, pcc, pcd, pdc, pdd)
 
 # %%
-
 def calculate_payoff_matrix(benefit, cost, delta, epsilon):
     """Calculates the payoffs $\pi(i, j)$ for i and j in Delta.
 
@@ -165,22 +164,16 @@ def infer_best_response_and_expected_payoffs(history, payoff_matrix):
     else:
         # we have to choose the best response from [0, 15]
         expected_payoffs[16:32] = -np.inf
-    # print(expected_payoffs)
+    #print(expected_payoffs)
 
     bs = np.argmax(expected_payoffs)
     exp_p = np.max(expected_payoffs)
 
     return bs, exp_p
 
-mat = calculate_payoff_matrix(benefit, cost, delta, epsilon)
-bs,exp_p = infer_best_response_and_expected_payoffs([(C,C),(D,C),(C,D),(C,C)], mat)
-# bs,exp_p = infer_best_response_and_expected_payoffs([(D,C),(C,D),(D,D),(C,C),(C,C)], mat)   # WSLS-c
-bs,exp_p
 
 # %%
-def long_term_total_payoff(
-    opening_payoffs, exp_p, delta
-):
+def long_term_total_payoff(opening_payoffs, exp_p, delta):
     """Compute the long term payoffs of the strategy against the opponent."""
     payoffs = 0
     for turn, turn_payoff in enumerate(opening_payoffs):

--- a/tests/test_mockup.py
+++ b/tests/test_mockup.py
@@ -2,60 +2,101 @@
 # At some point we will create a Python module for our code and this won't
 # be necessary
 
-import sys
+import sys,os
 
-sys.path.append("src/")
+script_dir = os.path.dirname(os.path.abspath(__file__))
+src_dir = os.path.join(script_dir, "../src")
+
+sys.path.append(src_dir)
 
 import mockup as mcu
-
 import numpy as np
 
 from axelrod.action import Action
 
 C, D = Action.C, Action.D
 
+import unittest
 
-def test_calculate_payoff_matrix():
-    benefit, cost, delta, epsilon = 2, 1, 0.999, 0
+class TestMockup(unittest.TestCase):
 
-    matrix = mcu.calculate_payoff_matrix(benefit, cost, delta, epsilon)
+    def test_calculate_payoff_matrix(self):
+        benefit, cost, delta, epsilon = 2, 1, 0.999, 0
 
-    # Dimension
-    assert matrix.shape == (32, 32)
+        matrix = mcu.calculate_payoff_matrix(benefit, cost, delta, epsilon)
 
-    # ALLD
-    assert np.isclose(matrix[0, 0], 0)
-    assert np.isclose(matrix[0, 31], 2)
+        # Dimension
+        self.assertEqual(matrix.shape, (32, 32))
 
-    # ALLC
-    assert np.isclose(matrix[31, 0], -1)
-    assert np.isclose(matrix[31, 26], 1)  # TFT (C)
-    assert np.isclose(matrix[31, 10], 0.998)  # TFT (D)
+        # ALLD
+        self.assertAlmostEqual(matrix[0, 0], 0)
+        self.assertAlmostEqual(matrix[0, 31], 2)
 
-    # TFT
-    assert np.isclose(matrix[26, 26], 1)
-    assert np.isclose(matrix[26, 25], 1)  # WSLS
+        # ALLC
+        self.assertAlmostEqual(matrix[31, 0], -1)
+        self.assertAlmostEqual(matrix[31, 26], 1)  # TFT (C)
+        self.assertAlmostEqual(matrix[31, 10], 0.998)  # TFT (D)
 
-
-def test_posterior_distribution_TFT_C():
-    history = [(C, C), (D, C), (C, D), (D, C), (D, D), (D, D)]
-    posterior = mcu.posterior_distribution(history)
-    assert np.argmax(posterior) == 26
+        # TFT
+        self.assertAlmostEqual(matrix[26, 26], 1)
+        self.assertAlmostEqual(matrix[26, 25], 1)  # WSLS
 
 
-def test_posterior_distribution_TFT_D():
-    history = [(C, D), (C, C), (D, C), (D, D), (D, D), (D, D)]
-    posterior = mcu.posterior_distribution(history)
-    assert np.argmax(posterior) == 10
+    def test_posterior_distribution(self):
+        # not enough history => uniform distribution
+        history = [(C,C)]
+        expected = np.array([1/16] * 16)
+        np.testing.assert_allclose(mcu.posterior_distribution(history), expected)
+
+        # when p_cc = 0
+        history = [(C,C),(D,D)]
+        expected = np.array([1/8] * 8 + [0] * 8)
+        np.testing.assert_allclose(mcu.posterior_distribution(history), expected)
+
+        # when p_cc = 0, p_dd = 1
+        history = [(C,C),(D,D),(D,C)]
+        expected = np.array([0, 0.25] * 4 + [0] * 8)
+        np.testing.assert_allclose(mcu.posterior_distribution(history), expected)
+
+        # when p_cc = 0, p_dd = 1, p_dc = 0, p_cd = 1  (0101)
+        history = [(C,C),(D,D),(D,C),(C,D),(D,C)]
+        expected = np.array([0,0,0,0,0,1,0,0] + [0] * 8)
+        np.testing.assert_allclose(mcu.posterior_distribution(history), expected)
+
+        history = [(D,D),(D,D),(D,C)]
+        with self.assertRaises(Exception):
+            mcu.posterior_distribution(history)
 
 
-def test_posterior_distribution_WSLS_C():
-    history = [(C, C), (D, C), (C, D), (D, D), (D, C)]
-    posterior = mcu.posterior_distribution(history)
-    assert np.argmax(posterior) == 25
+    def test_posterior_distribution_TFT(self):
+        history = [(C, C), (D, C), (D, D), (C, D), (C, C)]
+        posterior = mcu.posterior_distribution(history)
+        self.assertEqual(np.argmax(posterior), 0b1100)
 
 
-def test_posterior_distribution_WSLS_D():
-    history = [(C, D), (D, D), (C, C), (C, C), (D, C), (D, D)]
-    posterior = mcu.posterior_distribution(history)
-    assert np.argmax(posterior) == 9
+    def test_posterior_distribution_WSLS(self):
+        history = [(C, C), (D, C), (C, D), (D, D), (C, C)]
+        posterior = mcu.posterior_distribution(history)
+        self.assertEqual(np.argmax(posterior), 0b1001)
+
+
+    def test_idx_to_strategy(self):
+        self.assertEqual(mcu.idx_to_strategy(0b00000), (D,D,D,D,D) )
+        self.assertEqual(mcu.idx_to_strategy(0b11001), (C,C,D,D,C) ) # WSLS-c=25
+        self.assertEqual(mcu.idx_to_strategy(0b01100), (D,C,C,D,D) ) # TFT-d=10
+
+
+    def test_calculate_payoff_matrix(self):
+        benefit,cost,delta,epsilon = 1.0,0.2,0.99,0
+        mat = mcu.calculate_payoff_matrix(benefit, cost, delta, epsilon)
+        self.assertEqual(mat.shape, (32,32))
+        self.assertAlmostEqual(mat[0][0], 0.0) # AllD vs AllD
+        self.assertAlmostEqual(mat[31][31], benefit-cost) # AllC vs AllC
+        self.assertAlmostEqual(mat[0][31], benefit) # AllD vs AllC
+        self.assertAlmostEqual(mat[31][0], -cost) # AllC vs AllD
+        self.assertAlmostEqual(mat[25][25], benefit-cost) # WSLS-c vs WSLS-c
+        self.assertTrue(np.all(mat[8] == mat[0])) # GT-d behaves like AllD
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mockup.py
+++ b/tests/test_mockup.py
@@ -132,6 +132,7 @@ class TestMockup(unittest.TestCase):
         self.assertAlmostEqual(exp_p, expected*(1.0-delta))
 
         # naive cooperator (do not retaliate even if defected)
+        # the best response is to keep defecting ((D,C) continues)
         history = [(D,C),(D,C)]
         bs,exp_p = mcu.infer_best_response_and_expected_payoffs(history, mat)
         self.assertEqual(bs, 0b00000)

--- a/tests/test_mockup.py
+++ b/tests/test_mockup.py
@@ -58,9 +58,9 @@ class TestMockup(unittest.TestCase):
         expected = np.array([0, 0.25] * 4 + [0] * 8)
         np.testing.assert_allclose(mcu.posterior_distribution(history), expected)
 
-        # when p_cc = 0, p_dd = 1, p_dc = 0, p_cd = 1  (0101)
+        # when p_cc = 0, p_dd = 1, p_cd = 0, p_dc = 1  (0011)
         history = [(C,C),(D,D),(D,C),(C,D),(D,C)]
-        expected = np.array([0,0,0,0,0,1,0,0] + [0] * 8)
+        expected = np.array([0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0])
         np.testing.assert_allclose(mcu.posterior_distribution(history), expected)
 
         history = [(D,D),(D,D),(D,C)]
@@ -71,7 +71,7 @@ class TestMockup(unittest.TestCase):
     def test_posterior_distribution_TFT(self):
         history = [(C, C), (D, C), (D, D), (C, D), (C, C)]
         posterior = mcu.posterior_distribution(history)
-        self.assertEqual(np.argmax(posterior), 0b1100)
+        self.assertEqual(np.argmax(posterior), 0b1010)
 
 
     def test_posterior_distribution_WSLS(self):


### PR DESCRIPTION
(Currently, work in progress, but this is a working code. More refactoring and testing are needed.)

I revised the `infer_best_response_and_expected_payoffs` function such that it takes the last move in the initial sequence.

First, we calculate the `posterior_distribution` to infer $p_CC,p_CD,p_DC,p_DD$. Then, we use this posterior distribution in `infer_best_response_and_expected_payoffs` function.
